### PR TITLE
Fix error when 'description' is not available for Meetup Group

### DIFF
--- a/eventizer/meetup.py
+++ b/eventizer/meetup.py
@@ -261,7 +261,7 @@ class Meetup(object):
             group.organizer = self._fetch_member(raw_group['organizer']['member_id'])
 
         group.rating = raw_group['rating']
-        group.description = raw_group['description']
+        group.description = raw_group.get('description', None)
         group.city = self.__parse_city(raw_group)
         group.category = self.__parse_category(raw_group['category'])
 


### PR DESCRIPTION
This is the error we want to squash:

```
[12:07:27] /usr/local/bin/eventizer -u "root" -p "root" -d "eventizer_puppetlabs_5752_27" --key **** "South-East-Puppet-User-Group" >> /home
/bitergia/devel/Automator/puppetlabs//log/launch_eventizer.log 2>&1
Traceback (most recent call last):
  File "/usr/local/bin/eventizer", line 97, in <module>
    main()
  File "/usr/local/bin/eventizer", line 42, in main
    group = backend.fetch(args.group)
  File "/usr/local/lib/python2.7/dist-packages/eventizer/meetup.py", line 144, in fetch
    return self._fetch_group(group_name)
  File "/usr/local/lib/python2.7/dist-packages/eventizer/meetup.py", line 170, in _fetch_group
    group = self.__parse_group(raw_group)
  File "/usr/local/lib/python2.7/dist-packages/eventizer/meetup.py", line 264, in __parse_group
    group.description = raw_group['description']
KeyError: 'description'
```
